### PR TITLE
[GCSI-647] upload to store step handling 

### DIFF
--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_android_app_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_android_app_action.rb
@@ -70,7 +70,7 @@ module Fastlane
             api_key: instabug_api_key,
             status: "failure",
             step: "build_app",
-            error_message: error_message
+            error_message:
           )
           raise e
         end

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_android_app_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_android_app_action.rb
@@ -61,7 +61,7 @@ module Fastlane
           UI.success("Android build completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message)
+          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :build_app)
           UI.error("Android build failed: #{error_message}")
 
           # Report build failure to Instabug

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_ios_app_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_ios_app_action.rb
@@ -70,7 +70,7 @@ module Fastlane
             api_key: instabug_api_key,
             status: "failure",
             step: "build_app",
-            error_message: error_message
+            error_message:
           )
           raise e
         end

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_ios_app_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_build_ios_app_action.rb
@@ -61,7 +61,7 @@ module Fastlane
           UI.success("iOS build completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message)
+          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :build_app)
           UI.error("iOS build failed: #{error_message}")
 
           # Report build failure to Instabug

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_app_store_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_app_store_action.rb
@@ -132,7 +132,7 @@ module Fastlane
       def self.detect_app_version(params)
         return params[:app_version] if params[:app_version]
 
-        ipa = params[:ipa]
+        ipa = params[:ipa] || Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
         return nil unless ipa && File.exist?(ipa)
 
         begin

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_app_store_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_app_store_action.rb
@@ -1,4 +1,5 @@
 require 'fastlane/action'
+require 'fastlane_core/ipa_file_analyser'
 require_relative '../helper/instabug_stores_upload_helper'
 
 module Fastlane
@@ -25,18 +26,24 @@ module Fastlane
             branch_name:,
             api_key: instabug_api_key,
             status: "inprogress",
-            step: "upload_to_the_store"
+            step: "upload_to_store"
           )
 
           # Execute the actual upload to App Store
           result = Actions::UploadToAppStoreAction.run(filtered_params)
+
+          # Extract version information for iOS
+          version_string = detect_app_version(params)
 
           # Report upload success to Instabug
           Helper::InstabugStoresUploadHelper.report_status(
             branch_name:,
             api_key: instabug_api_key,
             status: "success",
-            step: "upload_to_the_store"
+            step: "upload_to_store",
+            extras: {
+              version_string:
+            }.compact
           )
 
           UI.success("App Store upload completed successfully!")
@@ -51,7 +58,7 @@ module Fastlane
             branch_name:,
             api_key: instabug_api_key,
             status: "failure",
-            step: "upload_to_the_store",
+            step: "upload_to_store",
             error_message: e.message
           )
           raise e
@@ -119,6 +126,29 @@ module Fastlane
 
       def self.category
         :app_store_connect
+      end
+
+      # Detect app version
+      def self.detect_app_version(params)
+        return params[:app_version] if params[:app_version]
+
+        ipa = params[:ipa]
+        return nil unless ipa && File.exist?(ipa)
+
+        begin
+          version = FastlaneCore::IpaFileAnalyser.fetch_app_version(ipa)
+
+          if version.to_s.strip.empty?
+            UI.error("Could not extract version from IPA")
+            return nil
+          end
+
+          UI.success("Found app version: #{version}")
+          version
+        rescue StandardError => e
+          UI.verbose("Could not extract version from IPA: #{e.message}")
+          nil
+        end
       end
     end
   end

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_app_store_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_app_store_action.rb
@@ -49,7 +49,7 @@ module Fastlane
           UI.success("App Store upload completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message)
+          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :upload_to_store)
 
           UI.error("App Store upload failed: #{error_message}")
 
@@ -59,7 +59,7 @@ module Fastlane
             api_key: instabug_api_key,
             status: "failure",
             step: "upload_to_store",
-            error_message: e.message
+            error_message:
           )
           raise e
         end

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_play_store_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_play_store_action.rb
@@ -48,7 +48,7 @@ module Fastlane
           UI.success("Play Store upload completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message)
+          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :upload_to_store)
           UI.error("Play Store upload failed: #{error_message}")
 
           # Report upload failure to Instabug
@@ -57,7 +57,7 @@ module Fastlane
             api_key: instabug_api_key,
             status: "failure",
             step: "upload_to_store",
-            error_message: e.message
+            error_message:
           )
           raise e
         end

--- a/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_play_store_action.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/actions/instabug_upload_to_play_store_action.rb
@@ -162,7 +162,7 @@ module Fastlane
         # Add authentication parameters
         auth_keys = %i[key issuer json_key json_key_data root_url timeout]
         auth_keys.each do |key|
-          google_params[key] = params[key] if params[key].present?
+          google_params[key] = params[key]
         end
 
         google_params.compact

--- a/lib/fastlane/plugin/instabug_stores_upload/helper/instabug_stores_upload_helper.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/helper/instabug_stores_upload_helper.rb
@@ -14,21 +14,21 @@ module Fastlane
 
       # Extract the important part of an error message
       def self.extract_error_message(error_message)
-        return error_message unless error_message.is_a?(String)
-      
+        return error_message unless error_message.kind_of?(String)
+
         lines = error_message.split("\n")
         start_index = lines.find_index { |line| line.strip.start_with?("* What went wrong:") }
         end_index   = lines.find_index { |line| line.strip.start_with?("* Try:") }
-      
+
         if start_index && end_index && end_index > start_index
           extracted_lines = lines[(start_index + 1)...end_index].map(&:strip).reject(&:empty?)
           return extracted_lines.join(" ")[0, 250] unless extracted_lines.empty?
         end
-      
+
         # Fallback message
         "Your build was triggered but failed during execution. " \
-        "This could be due to missing environment variables or incorrect build credentials. " \
-        "Check CI logs for full details."
+          "This could be due to missing environment variables or incorrect build credentials. " \
+          "Check CI logs for full details."
       end
 
       def self.show_message

--- a/lib/fastlane/plugin/instabug_stores_upload/helper/instabug_stores_upload_helper.rb
+++ b/lib/fastlane/plugin/instabug_stores_upload/helper/instabug_stores_upload_helper.rb
@@ -11,9 +11,13 @@ module Fastlane
       # Default Base URL for Instabug API
       DEFAULT_INSTABUG_API_BASE_URL = "https://api.instabug.com".freeze
       INSTABUG_KEYS = %i[branch_name instabug_api_key instabug_api_base_url].freeze
+      FASTLANE_ERROR_MESSAGE = {
+        build_app: "Your build was triggered but failed during execution. This could be due to missing environment variables or incorrect build credentials. Check CI logs for full details.",
+        upload_to_store: "Something went wrong while uploading your build. Check your Fastlane run for more details."
+      }
 
       # Extract the important part of an error message
-      def self.extract_error_message(error_message)
+      def self.extract_error_message(error_message, step)
         return error_message unless error_message.kind_of?(String)
 
         lines = error_message.split("\n")
@@ -26,9 +30,7 @@ module Fastlane
         end
 
         # Fallback message
-        "Your build was triggered but failed during execution. " \
-          "This could be due to missing environment variables or incorrect build credentials. " \
-          "Check CI logs for full details."
+        FASTLANE_ERROR_MESSAGE[step]
       end
 
       def self.show_message

--- a/spec/instabug_build_android_app_action_spec.rb
+++ b/spec/instabug_build_android_app_action_spec.rb
@@ -58,7 +58,7 @@ describe Fastlane::Actions::InstabugBuildAndroidAppAction do
             body['status'] == 'success' &&
               body['branch_name'] == 'crash-fix/instabug-crash-456' &&
               body['step'] == 'build_app' &&
-              body['extras']['build_path'] == '/path/to/app.apk' &&
+              body['extras']['build_path'] == ['/path/to/app.apk'] &&
               body['extras']['build_time'].kind_of?(Integer)
           }.once
       end
@@ -93,7 +93,7 @@ describe Fastlane::Actions::InstabugBuildAndroidAppAction do
               status: 'failure',
               step: 'build_app',
               extras: {},
-              error_message: 'Build failed'
+              error_message: 'Your build was triggered but failed during execution. This could be due to missing environment variables or incorrect build credentials. Check CI logs for full details.'
             }.to_json
           )
       end

--- a/spec/instabug_build_ios_app_action_spec.rb
+++ b/spec/instabug_build_ios_app_action_spec.rb
@@ -55,7 +55,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
             body['status'] == 'success' &&
               body['branch_name'] == 'crash-fix/instabug-crash-123' &&
               body['step'] == 'build_app' &&
-              body['extras']['build_path'] == '/path/to/app.ipa' &&
+              body['extras']['build_path'] == ['/path/to/app.ipa'] &&
               body['extras']['build_time'].kind_of?(Integer)
           }.once
       end
@@ -76,7 +76,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
             body['status'] == 'success' &&
               body['branch_name'] == 'crash-fix/instabug-crash-123' &&
               body['step'] == 'build_app' &&
-              body['extras']['build_path'].nil? &&
+              body['extras']['build_path'] == [] &&
               body['extras']['build_time'].kind_of?(Integer)
           }.once
       end
@@ -99,7 +99,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
               status: 'failure',
               step: 'build_app',
               extras: {},
-              error_message: 'Build failed'
+              error_message: 'Your build was triggered but failed during execution. This could be due to missing environment variables or incorrect build credentials. Check CI logs for full details.'
             }.to_json
           )
       end

--- a/spec/instabug_upload_to_app_store_action_spec.rb
+++ b/spec/instabug_upload_to_app_store_action_spec.rb
@@ -19,7 +19,11 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
 
   describe '#run' do
     context 'when upload succeeds' do
-      it 'reports inprogress, calls upload action, and reports success' do
+      it 'reports inprogress, calls upload action, and reports success with version detection' do
+        # Mock IPA file analysis
+        allow(File).to receive(:exist?).with('test.ipa').and_return(true)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).with('test.ipa').and_return('1.2.3')
+
         expect(Fastlane::Actions::UploadToAppStoreAction).to receive(:run)
           .with(hash_including(ipa: 'test.ipa', skip_screenshots: true))
           .and_return('upload_result')
@@ -32,7 +36,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
             body: {
               branch_name: 'crash-fix/instabug-crash-123',
               status: 'inprogress',
-              step: 'upload_to_the_store',
+              step: 'upload_to_store',
               extras: {},
               error_message: nil
             }.to_json,
@@ -48,8 +52,10 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
             body: {
               branch_name: 'crash-fix/instabug-crash-123',
               status: 'success',
-              step: 'upload_to_the_store',
-              extras: {},
+              step: 'upload_to_store',
+              extras: {
+                version_string: '1.2.3'
+              },
               error_message: nil
             }.to_json,
             headers: {
@@ -58,6 +64,59 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
               'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
             }
           ).once
+      end
+
+      it 'uses app_version parameter when provided' do
+        params_with_version = valid_params.merge(app_version: '2.0.0')
+
+        expect(Fastlane::Actions::UploadToAppStoreAction).to receive(:run)
+          .with(hash_including(ipa: 'test.ipa', skip_screenshots: true, app_version: '2.0.0'))
+          .and_return('upload_result')
+
+        result = described_class.run(params_with_version)
+
+        expect(result).to eq('upload_result')
+        expect(WebMock).to have_requested(:patch, api_endpoint)
+          .with { |req|
+            body = JSON.parse(req.body)
+            body['status'] == 'success' &&
+              body['extras']['version_string'] == '2.0.0'
+          }.once
+      end
+
+      it 'handles IPA extraction failure gracefully' do
+        allow(File).to receive(:exist?).with('test.ipa').and_return(true)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).with('test.ipa').and_raise(StandardError.new('IPA analysis failed'))
+
+        expect(Fastlane::Actions::UploadToAppStoreAction).to receive(:run)
+          .and_return('upload_result')
+
+        result = described_class.run(valid_params)
+
+        expect(result).to eq('upload_result')
+        expect(WebMock).to have_requested(:patch, api_endpoint)
+          .with { |req|
+            body = JSON.parse(req.body)
+            body['status'] == 'success' &&
+              body['extras'].empty?
+          }.once
+      end
+
+      it 'handles missing IPA file gracefully' do
+        allow(File).to receive(:exist?).with('test.ipa').and_return(false)
+
+        expect(Fastlane::Actions::UploadToAppStoreAction).to receive(:run)
+          .and_return('upload_result')
+
+        result = described_class.run(valid_params)
+
+        expect(result).to eq('upload_result')
+        expect(WebMock).to have_requested(:patch, api_endpoint)
+          .with { |req|
+            body = JSON.parse(req.body)
+            body['status'] == 'success' &&
+              body['extras'].empty?
+          }.once
       end
     end
 
@@ -76,7 +135,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
             body: {
               branch_name: 'crash-fix/instabug-crash-123',
               status: 'failure',
-              step: 'upload_to_the_store',
+              step: 'upload_to_store',
               extras: {},
               error_message: 'Upload failed'
             }.to_json
@@ -115,6 +174,65 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
 
         expect(result).to eq('upload_result')
         expect(WebMock).not_to have_requested(:patch, api_endpoint)
+      end
+    end
+  end
+
+  describe '.detect_app_version' do
+    let(:params) { { ipa: 'test.ipa' } }
+
+    context 'when app_version is provided in parameters' do
+      it 'returns the parameter value' do
+        params_with_version = params.merge(app_version: '1.5.0')
+
+        result = described_class.detect_app_version(params_with_version)
+
+        expect(result).to eq('1.5.0')
+      end
+    end
+
+    context 'when app_version is not provided' do
+      it 'extracts from IPA file when available' do
+        allow(File).to receive(:exist?).with('test.ipa').and_return(true)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).with('test.ipa').and_return('3.2.1')
+
+        result = described_class.detect_app_version(params)
+
+        expect(result).to eq('3.2.1')
+      end
+
+      it 'returns nil when IPA extraction fails' do
+        allow(File).to receive(:exist?).with('test.ipa').and_return(true)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).with('test.ipa').and_raise(StandardError.new('Failed'))
+
+        result = described_class.detect_app_version(params)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when IPA file does not exist' do
+        allow(File).to receive(:exist?).with('test.ipa').and_return(false)
+
+        result = described_class.detect_app_version(params)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when no IPA path is provided' do
+        params_without_ipa = {}
+
+        result = described_class.detect_app_version(params_without_ipa)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when version string is empty' do
+        allow(File).to receive(:exist?).with('test.ipa').and_return(true)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).with('test.ipa').and_return('')
+
+        result = described_class.detect_app_version(params)
+
+        expect(result).to be_nil
       end
     end
   end

--- a/spec/instabug_upload_to_app_store_action_spec.rb
+++ b/spec/instabug_upload_to_app_store_action_spec.rb
@@ -137,7 +137,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
               status: 'failure',
               step: 'upload_to_store',
               extras: {},
-              error_message: 'Upload failed'
+              error_message: 'Something went wrong while uploading your build. Check your Fastlane run for more details.'
             }.to_json
           )
       end

--- a/spec/instabug_upload_to_play_store_action_spec.rb
+++ b/spec/instabug_upload_to_play_store_action_spec.rb
@@ -139,7 +139,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
               status: 'failure',
               step: 'upload_to_store',
               extras: {},
-              error_message: 'Upload failed'
+              error_message: 'Something went wrong while uploading your build. Check your Fastlane run for more details.'
             }.to_json
           )
       end

--- a/spec/instabug_upload_to_play_store_action_spec.rb
+++ b/spec/instabug_upload_to_play_store_action_spec.rb
@@ -232,15 +232,6 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
 
         expect(result).to be_nil
       end
-
-      it 'returns nil when package_name is missing' do
-        params_without_package = params.except(:package_name)
-
-        result = described_class.detect_version_code(params_without_package)
-
-        expect(result).to be_nil
-        expect(Fastlane::Actions::GooglePlayTrackVersionCodesAction).not_to have_received(:run)
-      end
     end
   end
 

--- a/spec/instabug_upload_to_play_store_action_spec.rb
+++ b/spec/instabug_upload_to_play_store_action_spec.rb
@@ -7,7 +7,8 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
       instabug_api_key: 'test-api-key',
       package_name: 'com.example.app',
       aab: 'test.aab',
-      track: 'internal'
+      track: 'internal',
+      json_key: 'path/to/key.json'
     }
   end
 
@@ -16,6 +17,10 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
   before do
     stub_request(:patch, api_endpoint)
       .to_return(status: 200, body: '{}', headers: {})
+
+    # Mock the GooglePlayTrackVersionCodesAction to avoid actual API calls
+    allow(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+      .and_return(['123', '122', '121'])
   end
 
   describe '#run' do
@@ -33,7 +38,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
             body: {
               branch_name: 'crash-fix/instabug-crash-456',
               status: 'inprogress',
-              step: 'upload_to_the_store',
+              step: 'upload_to_store',
               extras: {},
               error_message: nil
             }.to_json,
@@ -49,8 +54,8 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
             body: {
               branch_name: 'crash-fix/instabug-crash-456',
               status: 'success',
-              step: 'upload_to_the_store',
-              extras: {},
+              step: 'upload_to_store',
+              extras: { version_code: '123' },
               error_message: nil
             }.to_json,
             headers: {
@@ -58,6 +63,61 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
               'Authorization' => 'Bearer test-api-key',
               'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
             }
+          ).once
+      end
+
+      it 'uses version_code from parameters when provided' do
+        params_with_version = valid_params.merge(version_code: '456')
+
+        expect(Fastlane::Actions::UploadToPlayStoreAction).to receive(:run)
+          .and_return('upload_result')
+
+        result = described_class.run(params_with_version)
+
+        expect(result).to eq('upload_result')
+        expect(WebMock).to have_requested(:patch, api_endpoint)
+          .with(
+            body: hash_including(
+              extras: { version_code: '456' }
+            )
+          ).once
+      end
+
+      it 'handles Google Play API failure gracefully' do
+        allow(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+          .and_raise(StandardError.new('API Error'))
+
+        expect(Fastlane::Actions::UploadToPlayStoreAction).to receive(:run)
+          .and_return('upload_result')
+
+        result = described_class.run(valid_params)
+
+        expect(result).to eq('upload_result')
+        expect(WebMock).to have_requested(:patch, api_endpoint)
+          .with(
+            body: hash_including(
+              status: 'success',
+              extras: {}
+            )
+          ).once
+      end
+
+      it 'handles empty version codes from Google Play' do
+        allow(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+          .and_return([])
+
+        expect(Fastlane::Actions::UploadToPlayStoreAction).to receive(:run)
+          .and_return('upload_result')
+
+        result = described_class.run(valid_params)
+
+        expect(result).to eq('upload_result')
+        expect(WebMock).to have_requested(:patch, api_endpoint)
+          .with(
+            body: hash_including(
+              status: 'success',
+              extras: {}
+            )
           ).once
       end
     end
@@ -77,7 +137,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
             body: {
               branch_name: 'crash-fix/instabug-crash-456',
               status: 'failure',
-              step: 'upload_to_the_store',
+              step: 'upload_to_store',
               extras: {},
               error_message: 'Upload failed'
             }.to_json
@@ -112,10 +172,74 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
         expect(Fastlane::Actions::UploadToPlayStoreAction).to receive(:run)
           .and_return('upload_result')
 
+        # Should still try to detect version code even for non-matching branches
+        expect(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+          .and_return(['123'])
+
         result = described_class.run(params)
 
         expect(result).to eq('upload_result')
         expect(WebMock).not_to have_requested(:patch, api_endpoint)
+      end
+    end
+  end
+
+  describe '.detect_version_code' do
+    let(:params) do
+      {
+        package_name: 'com.example.app',
+        track: 'production',
+        json_key: 'path/to/key.json'
+      }
+    end
+
+    context 'when version_code is provided in parameters' do
+      it 'returns the parameter value' do
+        params_with_version = params.merge(version_code: '789')
+
+        result = described_class.detect_version_code(params_with_version)
+
+        expect(result).to eq('789')
+        expect(Fastlane::Actions::GooglePlayTrackVersionCodesAction).not_to have_received(:run)
+      end
+    end
+
+    context 'when version_code is not in parameters' do
+      it 'fetches from Google Play Console' do
+        allow(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+          .with(hash_including(package_name: 'com.example.app', track: 'production'))
+          .and_return(['456', '455', '454'])
+
+        result = described_class.detect_version_code(params)
+
+        expect(result).to eq('456')
+      end
+
+      it 'returns nil when Google Play returns empty array' do
+        allow(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+          .and_return([])
+
+        result = described_class.detect_version_code(params)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when Google Play API fails' do
+        allow(Fastlane::Actions::GooglePlayTrackVersionCodesAction).to receive(:run)
+          .and_raise(StandardError.new('API Error'))
+
+        result = described_class.detect_version_code(params)
+
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when package_name is missing' do
+        params_without_package = params.except(:package_name)
+
+        result = described_class.detect_version_code(params_without_package)
+
+        expect(result).to be_nil
+        expect(Fastlane::Actions::GooglePlayTrackVersionCodesAction).not_to have_received(:run)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'webmock/rspec'
 class Fastlane::Helper::InstabugStoresUploadHelper
   def self.filter_instabug_params(params, target_action_class)
     # In test environment, params are plain hashes - just filter them
-    return params.reject { |key, _value| INSTABUG_KEYS.include?(key) }
+    return params.except(*INSTABUG_KEYS)
   end
 end
 


### PR DESCRIPTION
Let me explain what happened here
for `upload_to_play_store` (Android)
- I couldn't get the version code from `Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_CODE]` 
- i changed our way for extracting version code and could test it normally using our app 
- our new way depends on `GooglePlayTrackVersionCodesAction` fastlane action, which gets all version codes in a specific track so that we can get the latest uploaded as it is executed after the upload success

for `upload_app_store` (IOS)
- I implemented our approach, normally fetch from IPA `FastlaneCore::IpaFileAnalyser.fetch_app_version(options[:ipa])`
- still not validated 
- will be validated during the POC 

 
- updated upload_to_play_store/ upload_to_app_store new default messages from design