### PR TITLE
[GCSI-744] feat: rebranding instabug to Luciq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
-# instabug_stores_upload plugin
+# luciq_agent_release_tracking plugin
 
-[![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-instabug_stores_upload)
+[![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-luciq_agent_release_tracking)
 
 ## Getting Started
 
-This project is a [_fastlane_](https://github.com/fastlane/fastlane) plugin. To get started with `fastlane-plugin-instabug_stores_upload`, add it to your project by running:
+This project is a [_fastlane_](https://github.com/fastlane/fastlane) plugin. To get started with `fastlane-plugin-luciq_agent_release_tracking`, add it to your project by running:
 
 ```bash
-fastlane add_plugin instabug_stores_upload
+fastlane add_plugin luciq_agent_release_tracking
 ```
 
-## About instabug_stores_upload
+## About luciq_agent_release_tracking
 
-Wrapper plugin for uploading builds to App Store and Play Store with Instabug-specific metadata reporting. This plugin provides custom actions that wrap the standard Fastlane actions and automatically report build and upload events to Instabug systems for better observability and integration into internal pipelines.
+Luciq agent for tracking release builds and uploads to App Store and Play Store with comprehensive metadata reporting. This plugin provides custom actions that wrap the standard Fastlane actions and automatically report build and upload events to Luciq systems for better observability and integration into internal pipelines.
 
 ### Available Actions
 
-- `instabug_build_ios_app` - Build iOS apps with Instabug reporting
-- `instabug_build_android_app` - Build Android apps with Instabug reporting
-- `instabug_upload_to_app_store` - Upload iOS builds to App Store with Instabug reporting
-- `instabug_upload_to_play_store` - Upload Android builds to Play Store with Instabug reporting
+- `luciq_build_ios_app` - Build iOS apps with Luciq agent reporting
+- `luciq_build_android_app` - Build Android apps with Luciq agent reporting
+- `luciq_upload_to_app_store` - Upload iOS builds to App Store with Luciq agent reporting
+- `luciq_upload_to_play_store` - Upload Android builds to Play Store with Luciq agent reporting
 
 ### Features
 
-- Automatic reporting of build and upload events to Instabug
-- Branch-based tracking for Instabug Agents observability
+- Automatic reporting of build and upload events to Luciq
+- Branch-based tracking for comprehensive release observability
 - Integration with existing Fastlane workflows
 - Support for both iOS and Android platforms
-- Secure API communication with Instabug services
+- Secure API communication with Luciq services
 
 ## Example
 
@@ -38,9 +38,9 @@ Check out the [example `Fastfile`](fastlane/Fastfile) to see how to use this plu
 #### iOS Build
 ```ruby
 lane :build_ios do
-  instabug_build_ios_app(
+  luciq_build_ios_app(
     branch_name: "main",
-    instabug_api_key: ENV["INSTABUG_API_KEY"],
+    luciq_api_key: ENV["LUCIQ_API_KEY"],
     workspace: "MyApp.xcworkspace",
     scheme: "MyApp",
     export_method: "app-store",
@@ -52,9 +52,9 @@ end
 #### Android Build
 ```ruby
 lane :build_android do
-  instabug_build_android_app(
+  luciq_build_android_app(
     branch_name: "main",
-    instabug_api_key: ENV["INSTABUG_API_KEY"],
+    luciq_api_key: ENV["LUCIQ_API_KEY"],
     task: "assembleRelease",
     project_dir: "android/",
     properties: {
@@ -70,9 +70,9 @@ end
 #### iOS Upload
 ```ruby
 lane :upload_ios do
-  instabug_upload_to_app_store(
+  luciq_upload_to_app_store(
     branch_name: "main",
-    instabug_api_key: ENV["INSTABUG_API_KEY"],
+    luciq_api_key: ENV["LUCIQ_API_KEY"],
     ipa: "path/to/your/app.ipa",
     skip_screenshots: true,
     skip_metadata: true
@@ -83,9 +83,9 @@ end
 #### Android Upload
 ```ruby
 lane :upload_android do
-  instabug_upload_to_play_store(
+  luciq_upload_to_play_store(
     branch_name: "main",
-    instabug_api_key: ENV["INSTABUG_API_KEY"],
+    luciq_api_key: ENV["LUCIQ_API_KEY"],
     package_name: "com.example.app",
     aab: "path/to/your/app.aab",
     track: "internal",

--- a/fastlane-plugin-luciq_agent_release_tracking.gemspec
+++ b/fastlane-plugin-luciq_agent_release_tracking.gemspec
@@ -1,14 +1,14 @@
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'fastlane/plugin/instabug_stores_upload/version'
+require 'fastlane/plugin/luciq_agent_release_tracking/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'fastlane-plugin-instabug_stores_upload'
-  spec.version       = Fastlane::InstabugStoresUpload::VERSION
-  spec.author        = 'Instabug'
-  spec.email         = 'backend-team@instabug.com'
+  spec.name          = 'fastlane-plugin-luciq_agent_release_tracking'
+  spec.version       = Fastlane::LuciqAgentReleaseTracking::VERSION
+  spec.author        = 'Luciq'
+  spec.email         = 'support@luciq.ai'
 
-  spec.summary       = 'Wrapper plugin for uploading builds to App Store and Play Store with Instabug-specific metadata reporting.'
+  spec.summary       = 'Luciq agent for tracking release builds and uploads to App Store and Play Store with comprehensive metadata reporting.'
   spec.homepage      = "https://github.com/Instabug/fastlane-plugin-instabug-stores-upload"
   spec.license       = "MIT"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,12 +1,12 @@
-# Fastfile for Instabug Stores Upload Plugin
+# Fastfile for Luciq Agent Release Tracking Plugin
 
-# Example lane for building iOS app with Instabug reporting
+# Example lane for building iOS app with Luciq reporting
 lane :build_ios_app do |options|
   branch_name = options[:branch_name]
 
-  instabug_build_ios_app(
+  luciq_build_ios_app(
     branch_name:,
-    instabug_api_key: ENV.fetch("INSTABUG_API_KEY", nil),
+    luciq_api_key: ENV.fetch("LUCIQ_API_KEY", nil),
     # All standard build_ios_app parameters are supported
     workspace: "MyApp.xcworkspace",
     scheme: "MyApp",
@@ -15,13 +15,13 @@ lane :build_ios_app do |options|
   )
 end
 
-# Example lane for building Android app with Instabug reporting
+# Example lane for building Android app with Luciq reporting
 lane :build_android_app do |options|
   branch_name = options[:branch_name]
 
-  instabug_build_android_app(
+  luciq_build_android_app(
     branch_name:,
-    instabug_api_key: ENV.fetch("INSTABUG_API_KEY", nil),
+    luciq_api_key: ENV.fetch("LUCIQ_API_KEY", nil),
     # All standard gradle parameters are supported
     task: "assembleRelease",
     project_dir: "android/",
@@ -34,26 +34,26 @@ lane :build_android_app do |options|
   )
 end
 
-# Example lane for uploading to App Store with Instabug reporting
+# Example lane for uploading to App Store with Luciq reporting
 lane :upload_to_app_store do |options|
   branch_name = options[:branch_name]
 
-  instabug_upload_to_app_store(
+  luciq_upload_to_app_store(
     branch_name:,
-    instabug_api_key: ENV.fetch("INSTABUG_API_KEY", nil),
+    luciq_api_key: ENV.fetch("LUCIQ_API_KEY", nil),
     # All standard upload_to_app_store parameters are supported
     ipa: "path/to/your/app.ipa",
     skip_waiting_for_build_processing: true
   )
 end
 
-# Example lane for uploading to Play Store with Instabug reporting
+# Example lane for uploading to Play Store with Luciq reporting
 lane :upload_to_play_store do |options|
   branch_name = options[:branch_name]
 
-  instabug_upload_to_play_store(
+  luciq_upload_to_play_store(
     branch_name:,
-    instabug_api_key: ENV.fetch("INSTABUG_API_KEY", nil),
+    luciq_api_key: ENV.fetch("LUCIQ_API_KEY", nil),
     # All standard upload_to_play_store parameters are supported
     aab: "path/to/your/app.aab",
     track: "internal"

--- a/lib/fastlane/plugin/luciq_agent_release_tracking.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking.rb
@@ -1,7 +1,7 @@
-require 'fastlane/plugin/instabug_stores_upload/version'
+require 'fastlane/plugin/luciq_agent_release_tracking/version'
 
 module Fastlane
-  module InstabugStoresUpload
+  module LuciqAgentReleaseTracking
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
       Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]
@@ -11,6 +11,6 @@ end
 
 # By default we want to import all available actions and helpers
 # A plugin can contain any number of actions and plugins
-Fastlane::InstabugStoresUpload.all_classes.each do |current|
+Fastlane::LuciqAgentReleaseTracking.all_classes.each do |current|
   require current
 end

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_agent_release_tracking_action.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_agent_release_tracking_action.rb
@@ -1,19 +1,19 @@
 require 'fastlane/action'
-require_relative '../helper/instabug_stores_upload_helper'
+require_relative '../helper/luciq_agent_release_tracking_helper'
 
 module Fastlane
   module Actions
-    class InstabugStoresUploadAction < Action
+    class LuciqAgentReleaseTrackingAction < Action
       def self.run(params)
-        UI.message("The instabug_stores_upload plugin is working!")
+        UI.message("The luciq_agent_release_tracking plugin is working!")
       end
 
       def self.description
-        "Wrapper plugin for uploading builds to App Store and Play Store with Instabug-specific metadata reporting."
+        "Luciq agent for tracking release builds and uploads to App Store and Play Store with comprehensive metadata reporting."
       end
 
       def self.authors
-        ["Instabug Company"]
+        ["Luciq Company"]
       end
 
       def self.return_value
@@ -22,7 +22,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        "This Fastlane plugin provides wrapper actions around the standard `upload_to_app_store` and `upload_to_play_store` actions. it automatically reports these to the Instabug systems via a secure HTTP request. This allows engineering teams to track build upload steps per branch and platform with better observability and integration into internal pipelines."
+        "This Fastlane plugin provides wrapper actions around the standard build and upload actions. It automatically reports build and upload events to the Luciq systems via secure HTTP requests. This allows engineering teams to track release pipeline steps per branch and platform with comprehensive observability and integration into internal systems."
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_build_android_app_action.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_build_android_app_action.rb
@@ -1,29 +1,29 @@
 require 'fastlane/action'
-require_relative '../helper/instabug_stores_upload_helper'
+require_relative '../helper/luciq_agent_release_tracking_helper'
 
 module Fastlane
   module Actions
-    class InstabugBuildAndroidAppAction < Action
+    class LuciqBuildAndroidAppAction < Action
       def self.run(params)
-        UI.message("Starting Instabug Android build...")
+        UI.message("Starting Luciq Android build...")
 
-        # Extract Instabug-specific parameters
+        # Extract Luciq-specific parameters
         branch_name = params[:branch_name]
-        instabug_api_key = params[:instabug_api_key]
+        luciq_api_key = params[:luciq_api_key]
 
         # Validate required parameters
         if branch_name.nil? || branch_name.empty?
-          UI.user_error!("branch_name is required for Instabug reporting")
+          UI.user_error!("branch_name is required for Luciq reporting")
         end
 
-        # Filter out Instabug-specific parameters before passing to gradle
-        filtered_params = Helper::InstabugStoresUploadHelper.filter_instabug_params(params, Actions::GradleAction)
+        # Filter out Luciq-specific parameters before passing to gradle
+        filtered_params = Helper::LuciqAgentReleaseTrackingHelper.filter_luciq_params(params, Actions::GradleAction)
 
         begin
-          # Report build start to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report build start to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "inprogress",
             step: "build_app"
           )
@@ -46,10 +46,10 @@ module Fastlane
             UI.success("Successfully found build artifact(s) at: #{build_path}")
           end
 
-          # Report build success to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report build success to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "success",
             step: "build_app",
             extras: {
@@ -61,13 +61,13 @@ module Fastlane
           UI.success("Android build completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :build_app)
+          error_message = Helper::LuciqAgentReleaseTrackingHelper.extract_error_message(e.message, :build_app)
           UI.error("Android build failed: #{error_message}")
 
-          # Report build failure to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report build failure to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "failure",
             step: "build_app",
             error_message:
@@ -77,11 +77,11 @@ module Fastlane
       end
 
       def self.description
-        "Build Android app with Instabug metadata reporting"
+        "Build Android app with Luciq agent metadata reporting"
       end
 
       def self.authors
-        ["Instabug Company"]
+        ["Luciq Company"]
       end
 
       def self.return_value
@@ -89,34 +89,34 @@ module Fastlane
       end
 
       def self.details
-        "This action wraps the standard gradle action and adds Instabug-specific metadata reporting. It tracks build events per branch and provides better observability for engineering teams."
+        "This action wraps the standard gradle action and adds Luciq agent metadata reporting. It tracks build events per branch and provides better observability for engineering teams."
       end
 
       def self.available_options
         # Start with the original gradle options
         options = Actions::GradleAction.available_options
 
-        # Add Instabug-specific options
-        instabug_options = [
+        # Add Luciq-specific options
+        luciq_options = [
           FastlaneCore::ConfigItem.new(
             key: :branch_name,
-            env_name: "INSTABUG_BRANCH_NAME",
+            env_name: "LUCIQ_BRANCH_NAME",
             description: "The branch name for tracking builds",
             optional: false,
             type: String
           ),
           FastlaneCore::ConfigItem.new(
-            key: :instabug_api_key,
-            env_name: "INSTABUG_API_KEY",
-            description: "Instabug API key for reporting build events",
+            key: :luciq_api_key,
+            env_name: "LUCIQ_API_KEY",
+            description: "Luciq API key for reporting build events",
             optional: false,
             type: String,
             sensitive: true
           ),
           FastlaneCore::ConfigItem.new(
-            key: :instabug_api_base_url,
-            env_name: "INSTABUG_API_BASE_URL",
-            description: "Instabug API base URL (defaults to https://api.instabug.com)",
+            key: :luciq_api_base_url,
+            env_name: "LUCIQ_API_BASE_URL",
+            description: "Luciq API base URL (defaults to https://api.instabug.com)",
             optional: true,
             type: String,
             skip_type_validation: true # Since we don't extract this param
@@ -124,7 +124,7 @@ module Fastlane
         ]
 
         # Combine both sets of options
-        options + instabug_options
+        options + luciq_options
       end
 
       def self.is_supported?(platform)
@@ -133,9 +133,9 @@ module Fastlane
 
       def self.example_code
         [
-          'instabug_build_android_app(
+          'luciq_build_android_app(
             branch_name: "main",
-            instabug_api_key: "your-api-key",
+            luciq_api_key: "your-api-key",
             task: "assembleRelease",
             project_dir: "android/",
             properties: {

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_build_ios_app_action.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_build_ios_app_action.rb
@@ -1,29 +1,29 @@
 require 'fastlane/action'
-require_relative '../helper/instabug_stores_upload_helper'
+require_relative '../helper/luciq_agent_release_tracking_helper'
 
 module Fastlane
   module Actions
-    class InstabugBuildIosAppAction < Action
+    class LuciqBuildIosAppAction < Action
       def self.run(params)
-        UI.message("Starting Instabug iOS build...")
+        UI.message("Starting Luciq iOS build...")
 
-        # Extract Instabug-specific parameters
+        # Extract Luciq-specific parameters
         branch_name = params[:branch_name]
-        instabug_api_key = params[:instabug_api_key]
+        luciq_api_key = params[:luciq_api_key]
 
         # Validate required parameters
         if branch_name.nil? || branch_name.empty?
-          UI.user_error!("branch_name is required for Instabug reporting")
+          UI.user_error!("branch_name is required for Luciq reporting")
         end
 
-        # Filter out Instabug-specific parameters before passing to build_ios_app
-        filtered_params = Helper::InstabugStoresUploadHelper.filter_instabug_params(params, Actions::BuildIosAppAction)
+        # Filter out Luciq-specific parameters before passing to build_ios_app
+        filtered_params = Helper::LuciqAgentReleaseTrackingHelper.filter_luciq_params(params, Actions::BuildIosAppAction)
 
         begin
-          # Report build start to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report build start to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "inprogress",
             step: "build_app"
           )
@@ -46,10 +46,10 @@ module Fastlane
             UI.error("No IPA path found.")
           end
 
-          # Report build success to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report build success to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "success",
             step: "build_app",
             extras: {
@@ -61,13 +61,13 @@ module Fastlane
           UI.success("iOS build completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :build_app)
+          error_message = Helper::LuciqAgentReleaseTrackingHelper.extract_error_message(e.message, :build_app)
           UI.error("iOS build failed: #{error_message}")
 
-          # Report build failure to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report build failure to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "failure",
             step: "build_app",
             error_message:
@@ -77,11 +77,11 @@ module Fastlane
       end
 
       def self.description
-        "Build iOS app with Instabug metadata reporting"
+        "Build iOS app with Luciq agent metadata reporting"
       end
 
       def self.authors
-        ["Instabug Company"]
+        ["Luciq Company"]
       end
 
       def self.return_value
@@ -89,34 +89,34 @@ module Fastlane
       end
 
       def self.details
-        "This action wraps the standard build_ios_app action and adds Instabug-specific metadata reporting. It tracks build events per branch and provides better observability for engineering teams."
+        "This action wraps the standard build_ios_app action and adds Luciq agent metadata reporting. It tracks build events per branch and provides better observability for engineering teams."
       end
 
       def self.available_options
         # Start with the original build_ios_app options
         options = Actions::BuildIosAppAction.available_options
 
-        # Add Instabug-specific options
-        instabug_options = [
+        # Add Luciq-specific options
+        luciq_options = [
           FastlaneCore::ConfigItem.new(
             key: :branch_name,
-            env_name: "INSTABUG_BRANCH_NAME",
+            env_name: "LUCIQ_BRANCH_NAME",
             description: "The branch name for tracking builds",
             optional: false,
             type: String
           ),
           FastlaneCore::ConfigItem.new(
-            key: :instabug_api_key,
-            env_name: "INSTABUG_API_KEY",
-            description: "Instabug API key for reporting build events",
+            key: :luciq_api_key,
+            env_name: "LUCIQ_API_KEY",
+            description: "Luciq API key for reporting build events",
             optional: false,
             type: String,
             sensitive: true
           ),
           FastlaneCore::ConfigItem.new(
-            key: :instabug_api_base_url,
-            env_name: "INSTABUG_API_BASE_URL",
-            description: "Instabug API base URL (defaults to https://api.instabug.com)",
+            key: :luciq_api_base_url,
+            env_name: "LUCIQ_API_BASE_URL",
+            description: "Luciq API base URL (defaults to https://api.instabug.com)",
             optional: true,
             type: String,
             skip_type_validation: true # Since we don't extract this param
@@ -124,7 +124,7 @@ module Fastlane
         ]
 
         # Combine both sets of options
-        options + instabug_options
+        options + luciq_options
       end
 
       def self.is_supported?(platform)
@@ -133,9 +133,9 @@ module Fastlane
 
       def self.example_code
         [
-          'instabug_build_ios_app(
+          'luciq_build_ios_app(
             branch_name: "main",
-            instabug_api_key: "your-api-key",
+            luciq_api_key: "your-api-key",
             workspace: "MyApp.xcworkspace",
             scheme: "MyApp",
             export_method: "app-store",

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_upload_to_app_store_action.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_upload_to_app_store_action.rb
@@ -1,30 +1,30 @@
 require 'fastlane/action'
 require 'fastlane_core/ipa_file_analyser'
-require_relative '../helper/instabug_stores_upload_helper'
+require_relative '../helper/luciq_agent_release_tracking_helper'
 
 module Fastlane
   module Actions
-    class InstabugUploadToAppStoreAction < Action
+    class LuciqUploadToAppStoreAction < Action
       def self.run(params)
-        UI.message("Starting Instabug App Store upload...")
+        UI.message("Starting Luciq App Store upload...")
 
-        # Extract Instabug-specific parameters
+        # Extract Luciq-specific parameters
         branch_name = params[:branch_name]
-        instabug_api_key = params[:instabug_api_key]
+        luciq_api_key = params[:luciq_api_key]
 
         # Validate required parameters
         if branch_name.nil? || branch_name.empty?
-          UI.user_error!("branch_name is required for Instabug reporting")
+          UI.user_error!("branch_name is required for Luciq reporting")
         end
 
-        # Filter out Instabug-specific parameters before passing to upload_to_app_store
-        filtered_params = Helper::InstabugStoresUploadHelper.filter_instabug_params(params, Actions::UploadToAppStoreAction)
+        # Filter out Luciq-specific parameters before passing to upload_to_app_store
+        filtered_params = Helper::LuciqAgentReleaseTrackingHelper.filter_luciq_params(params, Actions::UploadToAppStoreAction)
 
         begin
-          # Report upload start to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report upload start to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "inprogress",
             step: "upload_to_store"
           )
@@ -35,10 +35,10 @@ module Fastlane
           # Extract version information for iOS
           version_string = detect_app_version(params)
 
-          # Report upload success to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report upload success to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "success",
             step: "upload_to_store",
             extras: {
@@ -49,14 +49,14 @@ module Fastlane
           UI.success("App Store upload completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :upload_to_store)
+          error_message = Helper::LuciqAgentReleaseTrackingHelper.extract_error_message(e.message, :upload_to_store)
 
           UI.error("App Store upload failed: #{error_message}")
 
-          # Report upload failure to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report upload failure to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "failure",
             step: "upload_to_store",
             error_message:
@@ -66,11 +66,11 @@ module Fastlane
       end
 
       def self.description
-        "Upload to App Store with Instabug metadata reporting"
+        "Upload to App Store with Luciq agent metadata reporting"
       end
 
       def self.authors
-        ["Instabug Company"]
+        ["Luciq Company"]
       end
 
       def self.return_value
@@ -78,26 +78,26 @@ module Fastlane
       end
 
       def self.details
-        "This action wraps the standard upload_to_app_store action and adds Instabug-specific metadata reporting. It tracks upload events per branch and provides better observability for engineering teams."
+        "This action wraps the standard upload_to_app_store action and adds Luciq agent metadata reporting. It tracks upload events per branch and provides better observability for engineering teams."
       end
 
       def self.available_options
         # Start with the original upload_to_app_store options
         options = Actions::UploadToAppStoreAction.available_options
 
-        # Add Instabug-specific options
-        instabug_options = [
+        # Add Luciq-specific options
+        luciq_options = [
           FastlaneCore::ConfigItem.new(
             key: :branch_name,
-            env_name: "INSTABUG_BRANCH_NAME",
+            env_name: "LUCIQ_BRANCH_NAME",
             description: "The branch name for tracking uploads",
             optional: false,
             type: String
           ),
           FastlaneCore::ConfigItem.new(
-            key: :instabug_api_key,
-            env_name: "INSTABUG_API_KEY",
-            description: "Instabug API key for reporting upload events",
+            key: :luciq_api_key,
+            env_name: "LUCIQ_API_KEY",
+            description: "Luciq API key for reporting upload events",
             optional: false,
             type: String,
             sensitive: true
@@ -105,7 +105,7 @@ module Fastlane
         ]
 
         # Combine both sets of options
-        options + instabug_options
+        options + luciq_options
       end
 
       def self.is_supported?(platform)
@@ -114,9 +114,9 @@ module Fastlane
 
       def self.example_code
         [
-          'instabug_upload_to_app_store(
+          'luciq_upload_to_app_store(
             branch_name: "main",
-            instabug_api_key: "your-api-key",
+            luciq_api_key: "your-api-key",
             ipa: "path/to/your.ipa",
             skip_screenshots: true,
             skip_metadata: true

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_upload_to_play_store_action.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/actions/luciq_upload_to_play_store_action.rb
@@ -1,29 +1,29 @@
 require 'fastlane/action'
-require_relative '../helper/instabug_stores_upload_helper'
+require_relative '../helper/luciq_agent_release_tracking_helper'
 
 module Fastlane
   module Actions
-    class InstabugUploadToPlayStoreAction < Action
+    class LuciqUploadToPlayStoreAction < Action
       def self.run(params)
-        UI.message("Starting Instabug Play Store upload...")
+        UI.message("Starting Luciq Play Store upload...")
 
-        # Extract Instabug-specific parameters
+        # Extract Luciq-specific parameters
         branch_name = params[:branch_name]
-        instabug_api_key = params[:instabug_api_key]
+        luciq_api_key = params[:luciq_api_key]
 
         # Validate required parameters
         if branch_name.nil? || branch_name.empty?
-          UI.user_error!("branch_name is required for Instabug reporting")
+          UI.user_error!("branch_name is required for Luciq reporting")
         end
 
-        # Filter out Instabug-specific parameters before passing to upload_to_play_store
-        filtered_params = Helper::InstabugStoresUploadHelper.filter_instabug_params(params, Actions::UploadToPlayStoreAction)
+        # Filter out Luciq-specific parameters before passing to upload_to_play_store
+        filtered_params = Helper::LuciqAgentReleaseTrackingHelper.filter_luciq_params(params, Actions::UploadToPlayStoreAction)
 
         begin
-          # Report upload start to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report upload start to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "inprogress",
             step: "upload_to_store"
           )
@@ -34,10 +34,10 @@ module Fastlane
           # Extract version information for Android
           version_code = detect_version_code(params)
 
-          # Report upload success to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report upload success to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "success",
             step: "upload_to_store",
             extras: {
@@ -48,13 +48,13 @@ module Fastlane
           UI.success("Play Store upload completed successfully!")
           result
         rescue StandardError => e
-          error_message = Helper::InstabugStoresUploadHelper.extract_error_message(e.message, :upload_to_store)
+          error_message = Helper::LuciqAgentReleaseTrackingHelper.extract_error_message(e.message, :upload_to_store)
           UI.error("Play Store upload failed: #{error_message}")
 
-          # Report upload failure to Instabug
-          Helper::InstabugStoresUploadHelper.report_status(
+          # Report upload failure to Luciq
+          Helper::LuciqAgentReleaseTrackingHelper.report_status(
             branch_name:,
-            api_key: instabug_api_key,
+            api_key: luciq_api_key,
             status: "failure",
             step: "upload_to_store",
             error_message:
@@ -64,11 +64,11 @@ module Fastlane
       end
 
       def self.description
-        "Upload to Play Store with Instabug metadata reporting"
+        "Upload to Play Store with Luciq agent metadata reporting"
       end
 
       def self.authors
-        ["Instabug Company"]
+        ["Luciq Company"]
       end
 
       def self.return_value
@@ -76,26 +76,26 @@ module Fastlane
       end
 
       def self.details
-        "This action wraps the standard upload_to_play_store action and adds Instabug-specific metadata reporting. It tracks upload events per branch and provides better observability for engineering teams."
+        "This action wraps the standard upload_to_play_store action and adds Luciq agent metadata reporting. It tracks upload events per branch and provides better observability for engineering teams."
       end
 
       def self.available_options
         # Start with the original upload_to_play_store options
         options = Actions::UploadToPlayStoreAction.available_options
 
-        # Add Instabug-specific options
-        instabug_options = [
+        # Add Luciq-specific options
+        luciq_options = [
           FastlaneCore::ConfigItem.new(
             key: :branch_name,
-            env_name: "INSTABUG_BRANCH_NAME",
+            env_name: "LUCIQ_BRANCH_NAME",
             description: "The branch name for tracking uploads",
             optional: false,
             type: String
           ),
           FastlaneCore::ConfigItem.new(
-            key: :instabug_api_key,
-            env_name: "INSTABUG_API_KEY",
-            description: "Instabug API key for reporting upload events",
+            key: :luciq_api_key,
+            env_name: "LUCIQ_API_KEY",
+            description: "Luciq API key for reporting upload events",
             optional: false,
             type: String,
             sensitive: true
@@ -103,7 +103,7 @@ module Fastlane
         ]
 
         # Combine both sets of options
-        options + instabug_options
+        options + luciq_options
       end
 
       def self.is_supported?(platform)
@@ -112,9 +112,9 @@ module Fastlane
 
       def self.example_code
         [
-          'instabug_upload_to_play_store(
+          'luciq_upload_to_play_store(
             branch_name: "main",
-            instabug_api_key: "your-api-key",
+            luciq_api_key: "your-api-key",
             package_name: "com.example.app",
             aab: "path/to/your.aab",
             track: "internal",

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/helper/luciq_agent_release_tracking_helper.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/helper/luciq_agent_release_tracking_helper.rb
@@ -7,10 +7,10 @@ module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
 
   module Helper
-    class InstabugStoresUploadHelper
-      # Default Base URL for Instabug API
-      DEFAULT_INSTABUG_API_BASE_URL = "https://api.instabug.com".freeze
-      INSTABUG_KEYS = %i[branch_name instabug_api_key instabug_api_base_url].freeze
+    class LuciqAgentReleaseTrackingHelper
+      # Default Base URL for Luciq API
+      DEFAULT_LUCIQ_API_BASE_URL = "https://api.instabug.com".freeze
+      LUCIQ_KEYS = %i[branch_name luciq_api_key luciq_api_base_url].freeze
       FASTLANE_ERROR_MESSAGE = {
         build_app: "Your build was triggered but failed during execution. This could be due to missing environment variables or incorrect build credentials. Check CI logs for full details.",
         upload_to_store: "Something went wrong while uploading your build. Check your Fastlane run for more details."
@@ -34,16 +34,16 @@ module Fastlane
       end
 
       def self.show_message
-        UI.message("Hello from the instabug_stores_upload plugin helper!")
+        UI.message("Hello from the luciq_agent_release_tracking plugin helper!")
       end
 
-      # Filters out Instabug-specific parameters from the params configuration
+      # Filters out Luciq-specific parameters from the params configuration
       # and returns a new FastlaneCore::Configuration object with only the target action's parameters
-      def self.filter_instabug_params(params, target_action_class)
+      def self.filter_luciq_params(params, target_action_class)
         filtered_config = {}
         params.available_options.each do |option|
           key = option.key
-          filtered_config[key] = params[key] unless INSTABUG_KEYS.include?(key)
+          filtered_config[key] = params[key] unless LUCIQ_KEYS.include?(key)
         end
 
         FastlaneCore::Configuration.create(target_action_class.available_options, filtered_config)
@@ -52,7 +52,7 @@ module Fastlane
       def self.report_status(branch_name:, api_key:, status:, step:, extras: {}, error_message: nil)
         return unless branch_name.start_with?('crash-fix/instabug-crash-')
 
-        UI.message("📡 Reporting #{step} status to Instabug for #{branch_name}/#{status}")
+        UI.message("📡 Reporting #{step} status to Luciq for #{branch_name}/#{status}")
 
         make_api_request(
           branch_name:,
@@ -68,7 +68,7 @@ module Fastlane
         return unless api_key
 
         # Determine API base URL from env var or default
-        base_url = ENV['INSTABUG_API_BASE_URL'] || DEFAULT_INSTABUG_API_BASE_URL
+        base_url = ENV['LUCIQ_API_BASE_URL'] || DEFAULT_LUCIQ_API_BASE_URL
         uri = URI.parse("#{base_url}/api/web/public/agent_fastlane/status")
 
         payload = {
@@ -88,23 +88,23 @@ module Fastlane
           request = Net::HTTP::Patch.new(uri.path)
           request['Content-Type'] = 'application/json'
           request['Authorization'] = "Bearer #{api_key}"
-          request['User-Agent'] = "fastlane-plugin-instabug_stores_upload"
+          request['User-Agent'] = "fastlane-plugin-luciq_agent_release_tracking"
           request.body = payload.to_json
 
           response = http.request(request)
 
           case response.code.to_i
           when 200..299
-            UI.success("✅ Successfully reported to Instabug")
+            UI.success("✅ Successfully reported to Luciq")
           else
-            UI.error("❌ Unknown error reporting to Instabug: #{response.code} #{response.message}")
+            UI.error("❌ Unknown error reporting to Luciq: #{response.code} #{response.message}")
           end
         rescue Net::TimeoutError
-          UI.error("❌ Timeout while reporting to Instabug")
+          UI.error("❌ Timeout while reporting to Luciq")
         rescue Net::OpenTimeout
-          UI.error("❌ Connection timeout while reporting to Instabug")
+          UI.error("❌ Connection timeout while reporting to Luciq")
         rescue StandardError => e
-          UI.error("❌ Error reporting to Instabug: #{e.message}")
+          UI.error("❌ Error reporting to Luciq: #{e.message}")
         end
       end
     end

--- a/lib/fastlane/plugin/luciq_agent_release_tracking/version.rb
+++ b/lib/fastlane/plugin/luciq_agent_release_tracking/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  module InstabugStoresUpload
+  module LuciqAgentReleaseTracking
     VERSION = "0.1.0"
   end
 end

--- a/spec/instabug_stores_upload_action_spec.rb
+++ b/spec/instabug_stores_upload_action_spec.rb
@@ -1,9 +1,0 @@
-describe Fastlane::Actions::InstabugStoresUploadAction do
-  describe '#run' do
-    it 'prints a message' do
-      expect(Fastlane::UI).to receive(:message).with("The instabug_stores_upload plugin is working!")
-
-      Fastlane::Actions::InstabugStoresUploadAction.run(nil)
-    end
-  end
-end

--- a/spec/luciq_agent_release_tracking_action_spec.rb
+++ b/spec/luciq_agent_release_tracking_action_spec.rb
@@ -1,0 +1,9 @@
+describe Fastlane::Actions::LuciqAgentReleaseTrackingAction do
+  describe '#run' do
+    it 'prints a message' do
+      expect(Fastlane::UI).to receive(:message).with("The luciq_agent_release_tracking plugin is working!")
+
+      Fastlane::Actions::LuciqAgentReleaseTrackingAction.run(nil)
+    end
+  end
+end

--- a/spec/luciq_agent_release_tracking_helper_spec.rb
+++ b/spec/luciq_agent_release_tracking_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'webmock/rspec'
 
-describe Fastlane::Helper::InstabugStoresUploadHelper do
+describe Fastlane::Helper::LuciqAgentReleaseTrackingHelper do
   describe '.report_status' do
     let(:api_endpoint) { 'https://api.instabug.com/api/web/public/agent_fastlane/status' }
 
@@ -31,7 +31,7 @@ describe Fastlane::Helper::InstabugStoresUploadHelper do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
       end

--- a/spec/luciq_build_android_app_action_spec.rb
+++ b/spec/luciq_build_android_app_action_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Fastlane::Actions::InstabugBuildAndroidAppAction do
+describe Fastlane::Actions::LuciqBuildAndroidAppAction do
   let(:valid_params) do
     {
       branch_name: 'crash-fix/instabug-crash-456',
-      instabug_api_key: 'test-api-key',
+      luciq_api_key: 'test-api-key',
       task: 'assembleRelease',
       project_dir: 'android/',
       properties: {
@@ -48,7 +48,7 @@ describe Fastlane::Actions::InstabugBuildAndroidAppAction do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-api-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
 
@@ -105,7 +105,7 @@ describe Fastlane::Actions::InstabugBuildAndroidAppAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -115,7 +115,7 @@ describe Fastlane::Actions::InstabugBuildAndroidAppAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -193,7 +193,7 @@ describe Fastlane::Actions::InstabugBuildAndroidAppAction do
 
   describe 'metadata' do
     it 'has correct description' do
-      expect(described_class.description).to eq('Build Android app with Instabug metadata reporting')
+      expect(described_class.description).to eq('Build Android app with Luciq agent metadata reporting')
     end
 
     it 'supports Android platform only' do

--- a/spec/luciq_build_ios_app_action_spec.rb
+++ b/spec/luciq_build_ios_app_action_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Fastlane::Actions::InstabugBuildIosAppAction do
+describe Fastlane::Actions::LuciqBuildIosAppAction do
   let(:valid_params) do
     {
       branch_name: 'crash-fix/instabug-crash-123',
-      instabug_api_key: 'test-api-key',
+      luciq_api_key: 'test-api-key',
       workspace: 'Test.xcworkspace',
       scheme: 'Test',
       export_method: 'app-store'
@@ -45,7 +45,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-api-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
 
@@ -111,7 +111,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -121,7 +121,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -142,7 +142,7 @@ describe Fastlane::Actions::InstabugBuildIosAppAction do
 
   describe 'metadata' do
     it 'has correct description' do
-      expect(described_class.description).to eq('Build iOS app with Instabug metadata reporting')
+      expect(described_class.description).to eq('Build iOS app with Luciq agent metadata reporting')
     end
 
     it 'supports iOS and Mac platforms' do

--- a/spec/luciq_upload_to_app_store_action_spec.rb
+++ b/spec/luciq_upload_to_app_store_action_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Fastlane::Actions::InstabugUploadToAppStoreAction do
+describe Fastlane::Actions::LuciqUploadToAppStoreAction do
   let(:valid_params) do
     {
       branch_name: 'crash-fix/instabug-crash-123',
-      instabug_api_key: 'test-api-key',
+      luciq_api_key: 'test-api-key',
       ipa: 'test.ipa',
       skip_screenshots: true
     }
@@ -43,7 +43,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-api-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
 
@@ -61,7 +61,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-api-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
       end
@@ -149,7 +149,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -159,7 +159,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -239,7 +239,7 @@ describe Fastlane::Actions::InstabugUploadToAppStoreAction do
 
   describe 'metadata' do
     it 'has correct description' do
-      expect(described_class.description).to eq('Upload to App Store with Instabug metadata reporting')
+      expect(described_class.description).to eq('Upload to App Store with Luciq agent metadata reporting')
     end
 
     it 'supports iOS and Mac platforms' do

--- a/spec/luciq_upload_to_play_store_action_spec.rb
+++ b/spec/luciq_upload_to_play_store_action_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
+describe Fastlane::Actions::LuciqUploadToPlayStoreAction do
   let(:valid_params) do
     {
       branch_name: 'crash-fix/instabug-crash-456',
-      instabug_api_key: 'test-api-key',
+      luciq_api_key: 'test-api-key',
       package_name: 'com.example.app',
       aab: 'test.aab',
       track: 'internal',
@@ -45,7 +45,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-api-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
 
@@ -61,7 +61,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
             headers: {
               'Content-Type' => 'application/json',
               'Authorization' => 'Bearer test-api-key',
-              'User-Agent' => 'fastlane-plugin-instabug_stores_upload'
+              'User-Agent' => 'fastlane-plugin-luciq_agent_release_tracking'
             }
           ).once
       end
@@ -151,7 +151,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -161,7 +161,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
 
         expect do
           described_class.run(params)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Instabug reporting')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'branch_name is required for Luciq reporting')
       end
     end
 
@@ -237,7 +237,7 @@ describe Fastlane::Actions::InstabugUploadToPlayStoreAction do
 
   describe 'metadata' do
     it 'has correct description' do
-      expect(described_class.description).to eq('Upload to Play Store with Instabug metadata reporting')
+      expect(described_class.description).to eq('Upload to Play Store with Luciq agent metadata reporting')
     end
 
     it 'supports Android platform only' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,14 +10,14 @@ module SpecHelper
 end
 
 require 'fastlane' # to import the Action super class
-require 'fastlane/plugin/instabug_stores_upload' # import the actual plugin
+require 'fastlane/plugin/luciq_agent_release_tracking' # import the actual plugin
 require 'webmock/rspec'
 
 # Override the helper method for tests to handle plain hashes
-class Fastlane::Helper::InstabugStoresUploadHelper
-  def self.filter_instabug_params(params, target_action_class)
+class Fastlane::Helper::LuciqAgentReleaseTrackingHelper
+  def self.filter_luciq_params(params, target_action_class)
     # In test environment, params are plain hashes - just filter them
-    return params.except(*INSTABUG_KEYS)
+    return params.except(*LUCIQ_KEYS)
   end
 end
 


### PR DESCRIPTION
I didn't change the base URL `https://api.instabug.com` 
because AFAIK it will remain Instabug in the first release 
Please let me know if u have any concerns 